### PR TITLE
Change parameter order in docs to reflect actual order

### DIFF
--- a/src/Shape.elm
+++ b/src/Shape.elm
@@ -635,8 +635,8 @@ type alias StackConfig a =
 
 {-| The basis for constructing a stacked chart
 
-  - `labels`: Sorted list of labels
   - `values`: Sorted list of values, where every item is a `(yLow, yHigh)` pair.
+  - `labels`: Sorted list of labels
   - `extent`: The minimum and maximum y-value. Convenient for creating scales.
 
 -}


### PR DESCRIPTION
I thought this was a bit confusing.