### PR TITLE
Updates for typed-svg 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: elm
+elm: 0.19.1
 elm-test: 0.19.1-revision2
 elm-format: 0.8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-language: elm
-elm: 0.19.1-3
+language: node_js
 
 script:
   - npm run ci-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: elm
 elm: 0.19.1-3
-elm-test: 0.19.1-revision2
-elm-format: 0.8.1
+
+script:
+  - npm run ci-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: elm
-elm: 0.19.1
+elm: 0.19.1-3
 elm-test: 0.19.1-revision2
 elm-format: 0.8.1

--- a/examples/BackgroundGraph.elm
+++ b/examples/BackgroundGraph.elm
@@ -15,7 +15,7 @@ import TypedSvg exposing (circle, g, line, polygon, svg, title)
 import TypedSvg.Attributes exposing (class, fill, points, stroke, viewBox)
 import TypedSvg.Attributes.InPx exposing (cx, cy, r, strokeWidth, x1, x2, y1, y2)
 import TypedSvg.Core exposing (Svg, text)
-import TypedSvg.Types exposing (Fill(..))
+import TypedSvg.Types exposing (Paint(..))
 
 
 w : Float
@@ -117,7 +117,7 @@ linkElement graph edge =
     in
     line
         [ strokeWidth 1
-        , stroke <| Scale.convert colorScale source.x
+        , stroke <| Paint <| Scale.convert colorScale source.x
         , x1 source.x
         , y1 source.y
         , x2 target.x
@@ -144,7 +144,7 @@ hexagon ( x, y ) size attrs =
 nodeSize size node =
     hexagon ( node.x, node.y )
         size
-        [ fill <| Fill <| Scale.convert colorScale node.x
+        [ fill <| Paint <| Scale.convert colorScale node.x
         ]
         [ title [] [ text node.value.name ] ]
 
@@ -163,8 +163,8 @@ nodeElement node =
                 [ r 12
                 , cx node.label.x
                 , cy node.label.y
-                , fill FillNone
-                , stroke <| Scale.convert colorScale node.label.x
+                , fill PaintNone
+                , stroke <| Paint <| Scale.convert colorScale node.label.x
                 ]
                 []
             ]

--- a/examples/BackgroundGraph.elm
+++ b/examples/BackgroundGraph.elm
@@ -1,4 +1,4 @@
-module Background exposing (main)
+module BackgroundGraph exposing (main)
 
 {-| Part of a composition used for the background of my Elm Europe talk.
 -}

--- a/examples/BarChartRace.elm
+++ b/examples/BarChartRace.elm
@@ -28,7 +28,7 @@ import TypedSvg exposing (g, rect, svg, text_, tspan)
 import TypedSvg.Attributes exposing (class, fill, fontWeight, stroke, style, textAnchor, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (height, width, x, y)
 import TypedSvg.Core exposing (Svg, text)
-import TypedSvg.Types exposing (AnchorAlignment(..), Fill(..), FontWeight(..), Transform(..))
+import TypedSvg.Types exposing (AnchorAlignment(..), Paint(..), FontWeight(..), Transform(..))
 
 
 w : Float
@@ -355,7 +355,7 @@ viewBars colorScale xScale yScale data =
     List.map
         (\datum ->
             rect
-                [ fill (Fill (Scale.convert colorScale datum.category |> Maybe.withDefault Color.black))
+                [ fill <| Paint <| (Scale.convert colorScale datum.category |> Maybe.withDefault Color.black)
                 , height barSize
                 , x (Scale.convert xScale 0)
                 , y (Scale.convert yScale datum.rank)

--- a/examples/BarChartRace.elm
+++ b/examples/BarChartRace.elm
@@ -28,7 +28,7 @@ import TypedSvg exposing (g, rect, svg, text_, tspan)
 import TypedSvg.Attributes exposing (class, fill, fontWeight, stroke, style, textAnchor, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (height, width, x, y)
 import TypedSvg.Core exposing (Svg, text)
-import TypedSvg.Types exposing (AnchorAlignment(..), Paint(..), FontWeight(..), Transform(..))
+import TypedSvg.Types exposing (AnchorAlignment(..), FontWeight(..), Paint(..), Transform(..))
 
 
 w : Float

--- a/examples/Centroid.elm
+++ b/examples/Centroid.elm
@@ -15,7 +15,7 @@ import TypedSvg exposing (circle, g, svg)
 import TypedSvg.Attributes exposing (fill, stroke, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (cx, cy, r)
 import TypedSvg.Core exposing (Svg)
-import TypedSvg.Types exposing (Fill(..), Transform(..))
+import TypedSvg.Types exposing (Paint(..), Transform(..))
 
 
 w : Float
@@ -73,8 +73,8 @@ circular arcs =
     let
         makeSlice index datum =
             Path.element (Shape.arc datum)
-                [ fill <| Fill <| Maybe.withDefault Color.black <| Array.get index colors
-                , stroke Color.black
+                [ fill <| Paint <| Maybe.withDefault Color.black <| Array.get index colors
+                , stroke <| Paint Color.black
                 ]
 
         makeDot datum =
@@ -95,8 +95,8 @@ annular arcs =
     let
         makeSlice index datum =
             Path.element (Shape.arc { datum | innerRadius = radius - 60 })
-                [ fill <| Fill <| Maybe.withDefault Color.black <| Array.get index colors
-                , stroke Color.black
+                [ fill <| Paint <| Maybe.withDefault Color.black <| Array.get index colors
+                , stroke <| Paint Color.black
                 ]
 
         makeDot datum =

--- a/examples/CornerRadius.elm
+++ b/examples/CornerRadius.elm
@@ -11,7 +11,7 @@ import TypedSvg exposing (circle, g, svg)
 import TypedSvg.Attributes exposing (fill, stroke, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (cx, cy, r)
 import TypedSvg.Core exposing (Svg)
-import TypedSvg.Types exposing (Fill(..), Transform(..))
+import TypedSvg.Types exposing (Paint(..), Transform(..))
 
 
 w : Float
@@ -77,8 +77,8 @@ corner angle radius sign =
                 (sign * cornerRadius * cos angle + sqrt (radius ^ 2 - cornerRadius ^ 2) * sin angle)
                 (sign * cornerRadius * sin angle - sqrt (radius ^ 2 - cornerRadius ^ 2) * cos angle)
             ]
-        , stroke Color.black
-        , fill FillNone
+        , stroke <| Paint Color.black
+        , fill PaintNone
         ]
 
 
@@ -87,8 +87,8 @@ circular arcs =
     let
         makeSlice index datum =
             Path.element (Shape.arc datum)
-                [ fill <| Fill <| Maybe.withDefault Color.black <| Array.get index colors
-                , stroke Color.white
+                [ fill <| Paint <| Maybe.withDefault Color.black <| Array.get index colors
+                , stroke <| Paint Color.white
                 ]
 
         makeCorners : { a | startAngle : Float, endAngle : Float, outerRadius : Float } -> List (Svg msg)
@@ -108,8 +108,8 @@ annular arcs =
     let
         makeSlice index datum =
             Path.element (Shape.arc { datum | innerRadius = mainRadius - 60 })
-                [ fill <| Fill <| Maybe.withDefault Color.black <| Array.get index colors
-                , stroke Color.white
+                [ fill <| Paint <| Maybe.withDefault Color.black <| Array.get index colors
+                , stroke <| Paint Color.white
                 ]
 
         makeCorners { startAngle, endAngle, outerRadius, innerRadius } =

--- a/examples/CrimeViz.elm
+++ b/examples/CrimeViz.elm
@@ -20,7 +20,7 @@ import TypedSvg exposing (g, svg, text_)
 import TypedSvg.Attributes exposing (class, dy, fill, fontFamily, stroke, textAnchor, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (fontSize, height, strokeWidth, x, y)
 import TypedSvg.Core exposing (Svg, text)
-import TypedSvg.Types exposing (AnchorAlignment(..), Fill(..), Transform(..), em)
+import TypedSvg.Types exposing (AnchorAlignment(..), Paint(..), Transform(..), em)
 
 
 w : Float
@@ -126,9 +126,9 @@ view model =
             (List.map
                 (\{ accessor, label } ->
                     Path.element (line accessor)
-                        [ stroke (color label)
+                        [ stroke <| Paint <| color label
                         , strokeWidth 3
-                        , fill FillNone
+                        , fill PaintNone
                         ]
                 )
                 series
@@ -141,7 +141,7 @@ view model =
                             [ Translate (w - padding + 10) (padding + Scale.convert yScale (toFloat (accessor last)))
                             ]
                         ]
-                        [ text_ [ fill (Fill (color label)) ] [ text label ] ]
+                        [ text_ [ fill (Paint (color label)) ] [ text label ] ]
                 )
                 series
             )

--- a/examples/Curves.elm
+++ b/examples/Curves.elm
@@ -31,7 +31,7 @@ import TypedSvg exposing (g, line, rect, svg, text_)
 import TypedSvg.Attributes as Explicit exposing (fill, fontFamily, stroke, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (height, strokeWidth, width, x, x1, x2, y, y1, y2)
 import TypedSvg.Core exposing (Svg, text)
-import TypedSvg.Types exposing (Fill(..), Transform(..), percent)
+import TypedSvg.Types exposing (Paint(..), Transform(..), percent)
 
 
 w : Float
@@ -86,7 +86,7 @@ xGridLine index tick =
         , Explicit.y2 (percent 100)
         , x1 (Scale.convert xScale tick)
         , x2 (Scale.convert xScale tick)
-        , stroke Color.white
+        , stroke <| Paint Color.white
         , strokeWidth (Basics.max (toFloat (modBy 2 index)) 0.5)
         ]
         []
@@ -99,7 +99,7 @@ yGridLine index tick =
         , Explicit.x2 (percent 100)
         , y1 (Scale.convert yScale tick)
         , y2 (Scale.convert yScale tick)
-        , stroke Color.white
+        , stroke <| Paint Color.white
         , strokeWidth (Basics.max (toFloat (modBy 2 index)) 0.5)
         ]
         []
@@ -113,12 +113,12 @@ drawCurve : ( String, Curve, Color ) -> Svg msg
 drawCurve ( name, curve, color ) =
     List.map Just preparedPoints
         |> Shape.line curve
-        |> (\path -> Path.element path [ stroke color, fill FillNone, strokeWidth 2 ])
+        |> (\path -> Path.element path [ stroke (Paint color), fill PaintNone, strokeWidth 2 ])
 
 
 drawLegend : Int -> ( String, Curve, Color ) -> Svg msg
 drawLegend index ( name, curve, color ) =
-    text_ [ fill (Fill color), fontFamily [ "monospace" ], x padding, y (toFloat index * 20 + padding) ] [ text name ]
+    text_ [ fill (Paint color), fontFamily [ "monospace" ], x padding, y (toFloat index * 20 + padding) ] [ text name ]
 
 
 view : List ( String, Curve, Color ) -> Svg String
@@ -126,12 +126,12 @@ view model =
     div []
         [ Example.navigation "Curve type" exampleData
         , svg [ viewBox 0 0 w h ]
-            [ rect [ width w, height h, fill <| Fill <| Color.rgb255 223 223 223 ] []
+            [ rect [ width w, height h, fill <| Paint <| Color.rgb255 223 223 223 ] []
             , g [] <| List.indexedMap yGridLine <| Scale.ticks yScale 10
             , g [] <| List.indexedMap xGridLine <| Scale.ticks xScale 20
             , g [] <|
                 List.map drawCurve model
-            , g [] <| List.map (\( dx, dy ) -> Path.element circle [ fill (Fill Color.white), stroke Color.black, transform [ Translate dx dy ] ]) preparedPoints
+            , g [] <| List.map (\( dx, dy ) -> Path.element circle [ fill (Paint Color.white), stroke (Paint Color.black), transform [ Translate dx dy ] ]) preparedPoints
             , g [] <| List.indexedMap drawLegend <| model
             ]
         ]

--- a/examples/CustomPieChart.elm
+++ b/examples/CustomPieChart.elm
@@ -15,7 +15,7 @@ import TypedSvg exposing (g, svg, text_)
 import TypedSvg.Attributes exposing (dy, fill, stroke, textAnchor, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (height, width)
 import TypedSvg.Core exposing (Svg, text)
-import TypedSvg.Types exposing (AnchorAlignment(..), Fill(..), Transform(..), em)
+import TypedSvg.Types exposing (AnchorAlignment(..), Paint(..), Transform(..), em)
 
 
 w : Float
@@ -85,7 +85,7 @@ drawChart config model =
                     }
 
         makeSlice index datum =
-            Path.element (Shape.arc datum) [ fill <| Fill <| Maybe.withDefault Color.black <| Array.get index colors, stroke Color.white ]
+            Path.element (Shape.arc datum) [ fill <| Paint <| Maybe.withDefault Color.black <| Array.get index colors, stroke <| Paint Color.white ]
 
         makeLabel slice ( label, value ) =
             let

--- a/examples/ForceDirectedGraph.elm
+++ b/examples/ForceDirectedGraph.elm
@@ -22,7 +22,7 @@ import TypedSvg exposing (circle, g, line, svg, title)
 import TypedSvg.Attributes exposing (class, fill, stroke, viewBox)
 import TypedSvg.Attributes.InPx exposing (cx, cy, r, strokeWidth, x1, x2, y1, y2)
 import TypedSvg.Core exposing (Attribute, Svg, text)
-import TypedSvg.Types exposing (Fill(..))
+import TypedSvg.Types exposing (Paint(..))
 
 
 w : Float
@@ -192,7 +192,7 @@ linkElement graph edge =
     in
     line
         [ strokeWidth 1
-        , stroke (Color.rgb255 170 170 170)
+        , stroke <| Paint <| Color.rgb255 170 170 170
         , x1 source.x
         , y1 source.y
         , x2 target.x
@@ -204,8 +204,8 @@ linkElement graph edge =
 nodeElement node =
     circle
         [ r 2.5
-        , fill (Fill Color.black)
-        , stroke (Color.rgba 0 0 0 0)
+        , fill <| Paint Color.black
+        , stroke <| Paint <| Color.rgba 0 0 0 0
         , strokeWidth 7
         , onMouseDown node.id
         , cx node.label.x

--- a/examples/HistogramChart.elm
+++ b/examples/HistogramChart.elm
@@ -12,7 +12,7 @@ import TypedSvg exposing (g, rect, svg)
 import TypedSvg.Attributes exposing (class, fill, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (height, width, x, y)
 import TypedSvg.Core exposing (Svg)
-import TypedSvg.Types exposing (Fill(..), Transform(..))
+import TypedSvg.Types exposing (Paint(..), Transform(..))
 
 
 {-| We use addition here to approximate normal distribution.
@@ -87,7 +87,7 @@ column yScale { length, x0, x1 } =
         , y <| Scale.convert yScale (toFloat length)
         , width <| Scale.convert xScale x1 - Scale.convert xScale x0
         , height <| h - Scale.convert yScale (toFloat length) - 2 * padding
-        , fill <| Fill <| Color.rgb255 46 118 149
+        , fill <| Paint <| Color.rgb255 46 118 149
         ]
         []
 

--- a/examples/LineChart.elm
+++ b/examples/LineChart.elm
@@ -15,7 +15,7 @@ import TypedSvg exposing (g, svg)
 import TypedSvg.Attributes exposing (class, fill, stroke, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (strokeWidth)
 import TypedSvg.Core exposing (Svg)
-import TypedSvg.Types exposing (Fill(..), Transform(..))
+import TypedSvg.Types exposing (Paint(..), Transform(..))
 
 
 w : Float
@@ -86,8 +86,8 @@ view model =
         , g [ transform [ Translate (padding - 1) padding ] ]
             [ yAxis ]
         , g [ transform [ Translate padding padding ], class [ "series" ] ]
-            [ Path.element (area model) [ strokeWidth 3, fill <| Fill <| Color.rgba 1 0 0 0.54 ]
-            , Path.element (line model) [ stroke (Color.rgb 1 0 0), strokeWidth 3, fill FillNone ]
+            [ Path.element (area model) [ strokeWidth 3, fill <| Paint <| Color.rgba 1 0 0 0.54 ]
+            , Path.element (line model) [ stroke <| Paint <| Color.rgb 1 0 0, strokeWidth 3, fill PaintNone ]
             ]
         ]
 

--- a/examples/NorwegianCarSales.elm
+++ b/examples/NorwegianCarSales.elm
@@ -25,7 +25,7 @@ import TypedSvg exposing (g, svg, text_)
 import TypedSvg.Attributes exposing (class, fill, fontFamily, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (fontSize)
 import TypedSvg.Core exposing (Svg)
-import TypedSvg.Types exposing (Fill(..), Transform(..))
+import TypedSvg.Types exposing (Paint(..), Transform(..))
 
 
 exampleConfig : List ( String, StackConfig String )
@@ -144,7 +144,7 @@ view { values, labels, extent } =
         labelElement : String -> Float -> Svg msg
         labelElement label yPosition =
             g [ transform [ Translate (w - padding - labelsWidth + 10) yPosition ] ]
-                [ text_ [ fill (sampleColor label |> Fill) ] [ text label ] ]
+                [ text_ [ fill <| Paint <| sampleColor label ] [ text label ] ]
     in
     div []
         [ titleNavigation
@@ -170,7 +170,7 @@ titleNavigation =
 -}
 renderStream : ( ContinuousScale Float, ContinuousScale Float ) -> Color -> List ( Float, Float ) -> Svg msg
 renderStream scales color coords =
-    Path.element (toArea scales coords) [ fill (Fill color) ]
+    Path.element (toArea scales coords) [ fill (Paint color) ]
 
 
 {-| Create a svg path string that draws the area between two lines

--- a/examples/PadAngle.elm
+++ b/examples/PadAngle.elm
@@ -10,7 +10,7 @@ import Shape exposing (Arc, defaultPieConfig)
 import TypedSvg exposing (g, svg)
 import TypedSvg.Attributes exposing (fill, stroke, transform, viewBox)
 import TypedSvg.Core exposing (Svg)
-import TypedSvg.Types exposing (Fill(..), Transform(..))
+import TypedSvg.Types exposing (Paint(..), Transform(..))
 
 
 w : Float
@@ -59,8 +59,8 @@ circular arcs =
     let
         makeSlice index datum =
             Path.element (Shape.arc datum)
-                [ fill <| Fill <| Maybe.withDefault Color.black <| Array.get index colors
-                , stroke Color.black
+                [ fill <| Paint <| Maybe.withDefault Color.black <| Array.get index colors
+                , stroke <| Paint Color.black
                 ]
     in
     g [ transform [ Translate radius radius ] ]
@@ -73,8 +73,8 @@ annular arcs =
     let
         makeSlice index datum =
             Path.element (Shape.arc { datum | innerRadius = radius - 60 })
-                [ fill <| Fill <| Maybe.withDefault Color.black <| Array.get index colors
-                , stroke Color.black
+                [ fill <| Paint <| Maybe.withDefault Color.black <| Array.get index colors
+                , stroke <| Paint Color.black
                 ]
     in
     g [ transform [ Translate (3 * radius + 20) radius ] ]

--- a/examples/Petals.elm
+++ b/examples/Petals.elm
@@ -11,7 +11,7 @@ import TypedSvg exposing (circle, svg)
 import TypedSvg.Attributes exposing (fill, viewBox)
 import TypedSvg.Attributes.InPx exposing (cx, cy, r)
 import TypedSvg.Core exposing (Svg)
-import TypedSvg.Types exposing (Fill(..))
+import TypedSvg.Types exposing (Paint(..))
 
 
 w : Float
@@ -38,7 +38,7 @@ makePetal i =
         angle =
             modBy 360 (floor (toFloat i * (3 - sqrt 5) * pi * 180 - sqrt (toFloat i) * 4))
     in
-    circle [ cx x, cy y, r 5, fill (Fill (color angle)) ] []
+    circle [ cx x, cy y, r 5, fill <| Paint <| color angle ] []
 
 
 view : List Int -> Svg msg

--- a/examples/PieChart.elm
+++ b/examples/PieChart.elm
@@ -11,7 +11,7 @@ import TypedSvg exposing (g, svg, text_)
 import TypedSvg.Attributes exposing (dy, fill, stroke, textAnchor, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (height, width)
 import TypedSvg.Core exposing (Svg, text)
-import TypedSvg.Types exposing (AnchorAlignment(..), Fill(..), Transform(..), em)
+import TypedSvg.Types exposing (AnchorAlignment(..), Paint(..), Transform(..), em)
 
 
 w : Float
@@ -49,7 +49,7 @@ view model =
             model |> List.map Tuple.second |> Shape.pie { defaultPieConfig | outerRadius = radius }
 
         makeSlice index datum =
-            Path.element (Shape.arc datum) [ fill <| Fill <| Maybe.withDefault Color.black <| Array.get index colors, stroke Color.white ]
+            Path.element (Shape.arc datum) [ fill <| Paint <| Maybe.withDefault Color.black <| Array.get index colors, stroke <| Paint Color.white ]
 
         makeLabel slice ( label, value ) =
             let

--- a/examples/PopulationMinnesota.elm
+++ b/examples/PopulationMinnesota.elm
@@ -12,7 +12,7 @@ import TypedSvg exposing (g, rect, svg, text_)
 import TypedSvg.Attributes exposing (class, dy, fill, fontFamily, textAnchor, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (fontSize, height, width, x, y)
 import TypedSvg.Core exposing (Svg, text)
-import TypedSvg.Types exposing (AnchorAlignment(..), Fill(..), Transform(..), em)
+import TypedSvg.Types exposing (AnchorAlignment(..), Paint(..), Transform(..), em)
 
 
 main : Svg msg
@@ -92,7 +92,7 @@ column yScale ( year, values ) =
                 , x lowerY
                 , height bandwidth
                 , width (abs <| upperY - lowerY)
-                , fill (Fill color)
+                , fill <| Paint color
                 ]
                 []
     in

--- a/examples/StackedBarChart.elm
+++ b/examples/StackedBarChart.elm
@@ -11,7 +11,7 @@ import TypedSvg exposing (g, rect, svg)
 import TypedSvg.Attributes exposing (class, fill, transform, viewBox)
 import TypedSvg.Attributes.InPx exposing (height, width, x, y)
 import TypedSvg.Core exposing (Svg)
-import TypedSvg.Types exposing (Fill(..), Transform(..))
+import TypedSvg.Types exposing (Paint(..), Transform(..))
 
 
 main : Svg msg
@@ -100,7 +100,7 @@ column xScale ( year, values ) =
                 , y <| lowerY
                 , width <| Scale.bandwidth xScale
                 , height <| (abs <| upperY - lowerY)
-                , fill (Fill color)
+                , fill <| Paint color
                 ]
                 []
     in

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -20,7 +20,7 @@
             "elm-community/graph": "6.0.0",
             "elm-community/intdict": "3.0.0",
             "elm-community/list-extra": "8.2.2",
-            "elm-community/typed-svg": "5.1.0",
+            "elm-community/typed-svg": "6.0.0",
             "elm-explorations/linear-algebra": "1.0.3",
             "elm-explorations/webgl": "1.1.1",
             "ericgj/elm-csv-decode": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "tests"
   },
   "scripts": {
-    "build-docs": "cd examples; elm-example-publisher"
+    "build-docs": "cd examples; elm-example-publisher",
+    "ci-tests": "elm-format --validate . && elm-test"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,8 @@
     "elm-example-publisher": "0.1.0"
   },
   "dependencies": {
-    "elm": "^0.19.1-3"
+    "elm": "^0.19.1-3",
+    "elm-format": "^0.8.2",
+    "elm-test": "^0.19.1-revision2"
   }
 }


### PR DESCRIPTION
In typed-svg 6.0.0 fill and stroke now both use the Paint type. I have updated the examples so the Paint type is used for fill and stroke.

Closes #71