### PR TITLE
docs: adjust padding in StackedBarChart example

### DIFF
--- a/examples/StackedBarChart.elm
+++ b/examples/StackedBarChart.elm
@@ -120,11 +120,11 @@ view { values, labels, extent } =
 
         xScale : BandScale Year
         xScale =
-            Scale.band { defaultBandConfig | paddingInner = 0.1, paddingOuter = 0.2 } ( 0, w - (padding.top + padding.bottom) ) years
+            Scale.band { defaultBandConfig | paddingInner = 0.1, paddingOuter = 0.2 } ( 0, w - (padding.left + padding.right) ) years
 
         yScale : ContinuousScale Float
         yScale =
-            Scale.linear ( h - (padding.left + padding.right), 0 ) extent
+            Scale.linear ( h - (padding.top + padding.bottom), 0 ) extent
                 |> Scale.nice 4
 
         scaledValues =


### PR DESCRIPTION
The horizontal and vertical padding values were swapped, causing the axes to be in the wrong place. It's not visible in this particular example, but noticeable to folks like me who copied the code and played with it