### PR TITLE
Fixed typo in Zoom docs

### DIFF
--- a/src/Zoom.elm
+++ b/src/Zoom.elm
@@ -52,7 +52,7 @@ Then handle update:
         case msg of
             ZoomMsg zoomMsg ->
                 ( { model
-                    | zoom = Zoom.update zoomMsg zoom.model
+                    | zoom = Zoom.update zoomMsg model.zoom
                   }
                 , Cmd.none
                 )


### PR DESCRIPTION
The `update` function was not correct in the docs for the Zoom component.