### PR TITLE
Switch to ryan-haskell/date-format

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -34,7 +34,7 @@
         "ianmackenzie/elm-units-prefixed": "2.0.0 <= v < 3.0.0",
         "justinmimbs/time-extra": "1.0.1 <= v < 2.0.0",
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
-        "ryannhg/date-format": "2.0.0 <= v < 3.0.0"
+        "ryan-haskell/date-format": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm/regex": "1.0.0 <= v < 2.0.0",

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -35,7 +35,7 @@
             "mpizenberg/elm-pointer-events": "5.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "rtfeldman/elm-iso8601-date-strings": "1.1.4",
-            "ryannhg/date-format": "2.3.0"
+            "ryan-haskell/date-format": "1.0.0"
         },
         "indirect": {
             "avh4/elm-fifo": "1.0.4",


### PR DESCRIPTION
Hello @gampleman 
at Holmusk we're using this package in our application (thanks for working on it!)
and this morning our CI started to fail with error like this:

```bash
-- CORRUPT PACKAGE DATA --------------------------------------------------------

I downloaded the source code for ryannhg/date-format 2.3.0 from:

    https://github.com/ryannhg/date-format/zipball/2.3.0/

But it looks like the hash of the archive has changed since publication:

  Expected: 70c67866fed499bec685f43f23fea279556757f2
    Actual: 86534146f5a550bb8e87b87a7484ea5732090bb5

This usually means that the package author moved the version tag, so report it
to them and see if that is the issue. Folks on Elm slack can probably help as
well.
```
We don't depend on this package directly, instead we're getting it as transitive dependency of elm-visualization.

It seems that the author changed his github handle (ryannhg -> ryan-haskell): https://github.com/ryan-haskell/date-format/commit/14abea13f8bf9626fa10a0612da5ed2d5fddbe11

Because of that elm-visualization is no longer buildable.
Switching to ryan-haskell/date-format fixes the build.
