### PR TITLE
Restore Ellie links on the examples site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "npm-run-all": "^4.1.5"
       },
       "devDependencies": {
-        "elm-example-publisher": "^2.0.2",
+        "elm-example-publisher": "^2.0.3",
         "netlify-plugin-cache": "^1.0.3"
       }
     },
@@ -2251,9 +2251,9 @@
       }
     },
     "node_modules/elm-example-publisher": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/elm-example-publisher/-/elm-example-publisher-2.0.2.tgz",
-      "integrity": "sha512-M3ZzLFUfdIoJJHHVWGgKa229pCKvWCGQX4/29PVnnaYaB+5vMrDCjf2G/xw+26bheisdTWaUesqtLCRuPdK9mA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/elm-example-publisher/-/elm-example-publisher-2.0.3.tgz",
+      "integrity": "sha512-q36KKVmW6t2/h25PJeoLaQrMs0Lbi6QUnG+/lvpxw5fa+cw9QRE7Q5Wch1z5Hz+4kJXCqY3qXQhRe3Hni/WUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/gampleman/elm-visualization#readme",
   "devDependencies": {
-    "elm-example-publisher": "^2.0.2",
+    "elm-example-publisher": "^2.0.3",
     "netlify-plugin-cache": "^1.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Problem

The "Edit on Ellie" links disappeared from the [examples site](https://elm-visualization.netlify.app/) after the upgrade to elm-example-publisher 2.0 (#193). The build logs show Ellies are still being published successfully to the Ellie API, but the links never render in the generated HTML.

## Root cause

A decoder bug in elm-example-publisher 2.0.2: `publishEllies` attaches `ellieLink` at the example's **top level** (matching its `Example` type), but `ExamplePublisher.elm`'s decoder read it from `Decode.at ["tags", "ellieLink"]`. `Decode.maybe` swallowed the mismatch, so `ellieLink` was always `Nothing` and `ellieLinkView` rendered nothing.

Verified end-to-end:
- Live site (`/ColorSpaceInterpolations/`): zero `ellie` references.
- Archived pre-upgrade site: `Edit on Ellie` → `ellie-app.com/rLmdYVnpzsva1` present.
- Standalone decode test on the exact JSON shape the publisher emits: old path → `Nothing`, fixed path → `Just <url>`.

## Fix

Fixed upstream in elm-example-publisher (decode the top-level `ellieLink` field) and released as [2.0.3](https://www.npmjs.com/package/elm-example-publisher/v/2.0.3). This PR bumps the devDependency `^2.0.2` → `^2.0.3`.

The elm-review CLI pin (2.10.2) in the lockfile is preserved.

## Verification

Links will return once Netlify rebuilds from this branch. Worth a quick `curl .../ColorSpaceInterpolations/ | grep -i ellie` on the deploy preview to confirm.